### PR TITLE
Updated to support kibana 6.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "health_metric_vis",
-    "version": "6.2.2",
+    "version": "6.3.0",
     "kibana": {
-        "version": "6.2.2"
+        "version": "6.3.0"
     },
     "author": "clamarque",
     "description": "change color of metric depending to the planned state of health",

--- a/public/health_metric_vis.js
+++ b/public/health_metric_vis.js
@@ -1,8 +1,8 @@
-import 'plugins/health_metric_vis/health_metric_vis.less';
-import mainTemplate from 'plugins/health_metric_vis/health_metric_vis_params.html';
+import './health_metric_vis.less';
+import { mainTemplate } from './health_metric_vis_params.html';
 import { VisFactoryProvider } from 'ui/vis/vis_factory';
 import { CATEGORY } from 'ui/vis/vis_category';
-import { VisSchemasProvider } from 'ui/vis/editors/default/schemas';
+import { Schemas } from 'ui/vis/editors/default/schemas';
 import { VisTypesRegistryProvider } from 'ui/registry/vis_types';
 import { vislibColorMaps } from 'ui/vislib/components/color/colormaps';
 import { HealthMetricVisComponent } from './health_metric_vis_controller';
@@ -11,11 +11,10 @@ import image from './images/icon-number.svg';
 
 // we also need to load the controller and used by the template
 
-// register the provider with the visTypes registry 
+// register the provider with the visTypes registry
 VisTypesRegistryProvider.register(HealthMetricVisProvider);
 
 function HealthMetricVisProvider(Private) {
-  const Schemas = Private(VisSchemasProvider);
   const VisFactory = Private(VisFactoryProvider);
 
   // return the visType object, which kibana will use to display and configure new
@@ -25,7 +24,7 @@ function HealthMetricVisProvider(Private) {
     name: 'health-metric',
     title: 'health-metric',
     image,
-    description: 'Displays a metric with a color according to the planned state of health.',
+    description: 'Displays a metric with a color according to the planned state of health',
     category: CATEGORY.DATA,
     visConfig: {
       component: HealthMetricVisComponent,


### PR DESCRIPTION
The release for 6.2.3 is not compatible with kibana 6.3.0. It currently breaks the visualization UI, this commit fixes that.